### PR TITLE
Add .DS_Store check to serverleaks module

### DIFF
--- a/privacyscanner/scanmodules/serverleaks.py
+++ b/privacyscanner/scanmodules/serverleaks.py
@@ -97,6 +97,7 @@ TRIALS = [
     ('.git/HEAD', 'ref:'),
     ('.svn/wc.db', 'SQLite'),
     ('core', 'ELF'),
+    ('.DS_Store', 'Bud1'),
 
     # Check for Database dumps
     # sqldump - MySQL/MariaDB


### PR DESCRIPTION
As requested in https://github.com/PrivacyScore/PrivacyScore/issues/42:

Checking for `Bud1` (the magic number) seems to be the easiest way to identify the `.DS_Store` files.

Should this also be added to https://github.com/PrivacyScore/PrivacyScore/blob/master/privacyscore/test_suites/serverleak.py? 