### PR TITLE
Fix --skip-dependencies bug that made all other commands unusable

### DIFF
--- a/privacyscanner/scanner.py
+++ b/privacyscanner/scanner.py
@@ -163,7 +163,7 @@ def print_master_config(args):
 
 def main():
     parser = argparse.ArgumentParser(description='Scan sites for privacy.')
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(dest='command')
 
     parser_run_workers = subparsers.add_parser('run_workers')
     parser_run_workers.add_argument('--config', help='Configuration_file')
@@ -189,7 +189,9 @@ def main():
     parser_print_master_config.set_defaults(func=print_master_config)
 
     args = parser.parse_args()
-    if args.skip_dependencies and not args.scan_modules:
+    if args.command is None:
+        parser.error('No arguments')
+    if args.command == 'scan' and args.skip_dependencies and not args.scan_modules:
         parser.error('--skip-dependencies can only be set when using --scans')
     try:
         args.func(args)


### PR DESCRIPTION
https://github.com/PrivacyScore/privacyscanner/commit/d13bc208f7be767c77d0146c246166d7b367bf3f implemented `--skip-dependencies` which fails if one isn't working in the `scan` argument space.

```
(privacyscanner) $ privacyscanner print_master_config
Traceback (most recent call last):
  File "/Users/malte/.pyenv/versions/privacyscanner/bin/privacyscanner", line 11, in <module>
    load_entry_point('privacyscanner', 'console_scripts', 'privacyscanner')()
  File "/Users/malte/src/python/privacyscanner/privacyscanner/scanner.py", line 192, in main
    if args.skip_dependencies and not args.scan_modules:
AttributeError: 'Namespace' object has no attribute 'skip_dependencies'
```

```
(privacyscanner) $ privacyscanner run_workers
Traceback (most recent call last):
  File "/Users/malte/.pyenv/versions/privacyscanner/bin/privacyscanner", line 11, in <module>
    load_entry_point('privacyscanner', 'console_scripts', 'privacyscanner')()
  File "/Users/malte/src/python/privacyscanner/privacyscanner/scanner.py", line 192, in main
    if args.skip_dependencies and not args.scan_modules:
AttributeError: 'Namespace' object has no attribute 'skip_dependencies'
```
```
(privacyscanner) 1 $ privacyscanner scan
usage: privacyscanner scan [-h] [--config CONFIG] [--results RESULTS]
                           [--import-results IMPORT_RESULTS]
                           [--scans SCAN_MODULES] [--skip-dependencies]
                           [--print]
                           site
privacyscanner scan: error: the following arguments are required: site
```

Having a `dest` on the subparsers also allows to check if no argument is provided and give a reasonable error message instead of an `AttributeError`.