### PR TITLE
Add option to save request and response headers

### DIFF
--- a/privacyscanner/scanmodules/chromedevtools/extractors/requests.py
+++ b/privacyscanner/scanmodules/chromedevtools/extractors/requests.py
@@ -22,6 +22,13 @@ class RequestsExtractor(Extractor):
             # is_tracker is only available if the trackerdetect mixin is enabled
             if 'is_tracker' in request:
                 request_dict['is_tracker'] = request['is_tracker'],
+            # Add headers if requested
+            # To enable this option, set SCAN_MODULE_OPTIONS in your config file to
+            # {'chromedevtools': {'RequestsExtractor.save_headers': True}}
+            # (or change it in a similar way)
+            if self.options.get('RequestsExtractor.save_headers', False):
+                request_dict['request_headers'] = request["headers"]
+                request_dict['response_headers'] = response["headers"]
             requests.append(request_dict)
         self.result['requests'] = requests
 

--- a/privacyscanner/scanner.py
+++ b/privacyscanner/scanner.py
@@ -48,6 +48,7 @@ def load_config(config_file):
                 break
         else:
             return config
+    config_file = Path(config_file)
     try:
         with config_file.open() as f:
             code = compile(f.read(), config_file.name, 'exec')


### PR DESCRIPTION
Some use cases require getting access to request and response headers of page loads. This PR adds that feature. To enable it, set your `SCAN_MODULE_OPTIONS` in your config file to include `'RequestsExtractor.saveHeaders': True` for the `chromedevtools` scan module. Minimal config example:

```python
SCAN_MODULE_OPTIONS = {'chromedevtools': {'RequestsExtractor.saveHeaders': True}}
```

This PR also fixes a problem with loading a config file using the `--config file.py` option, where the scanner would crash due to a missing cast of the parameter string to a Path object.